### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+---
+name: test
+
+"on":
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - README*
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - README*
+      - '**.md'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          # - windows-latest
+          # - macOS-latest
+        nim:
+          - '1.6.4'
+          - '1.6.x'
+          - 'stable'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: ${{ matrix.nim }}
+      - run: nimble install -Y
+      - run: nimble test -Y

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Valiant Wallet
+
+![test](https://github.com/frodo821/valiant-wallet/workflows/test/badge.svg)
+
 An Ethereum wallet library fully written in Nim
 
 ## Roadmap


### PR DESCRIPTION
- Nimの単体テストのCIを追加
  - master ブランチにPushした時にCIが起動する
    - Pushの場合に master のみに制限しているのには理由があります
    - 自分でPRを作って master にマージしようとした時に、Push側にブランチ名制限をいれていないと、pushのパイプラインとpull_requestのパイプラインの2つが同時に走ってしまうためです
    - 余分にCIが走ると待ち時間にも響くので、そうならないようにしています
  - PRを作った時にCIが起動する
- READMEにCIのステータスバッジを追加